### PR TITLE
Add orders access level

### DIFF
--- a/Content.Shared/Access/Components/IdCardConsoleComponent.cs
+++ b/Content.Shared/Access/Components/IdCardConsoleComponent.cs
@@ -72,6 +72,7 @@ public sealed partial class IdCardConsoleComponent : Component
         "Security",
         "Service",
         "Theatre",
+        "Orders", // DeltaV - Orders, see Resources/Prototypes/DeltaV/Access/cargo.yml
     };
 
     [Serializable, NetSerializable]

--- a/Resources/Locale/en-US/deltav/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/deltav/prototypes/access/accesses.ftl
@@ -1,0 +1,1 @@
+﻿id-card-access-level-orders = Orders

--- a/Resources/Locale/en-US/nyanotrasen/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/nyanotrasen/prototypes/access/accesses.ftl
@@ -1,0 +1,1 @@
+﻿id-card-access-level-mail = Mail

--- a/Resources/Prototypes/Access/cargo.yml
+++ b/Resources/Prototypes/Access/cargo.yml
@@ -17,3 +17,4 @@
   - Salvage
   - Cargo
   - Mail # Nyanotrasen - MailCarrier, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail-carrier.yml
+

--- a/Resources/Prototypes/Access/cargo.yml
+++ b/Resources/Prototypes/Access/cargo.yml
@@ -17,4 +17,4 @@
   - Salvage
   - Cargo
   - Mail # Nyanotrasen - MailCarrier, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail-carrier.yml
-
+  - Orders # Delta V - Orders, see Resources/Prototypes/DeltaV/Access/cargo.yml

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -31,3 +31,4 @@
   - Hydroponics
   - Atmospherics
   - Mail # Nyanotrasen - MailCarrier, see Resources/Prototypes/Nyanotrasen/Roles/Jobs/Cargo/mail-carrier.yml
+  - Orders # DeltaV - Orders, see Resources/Prototypes/DeltaV/Access/cargo.yml

--- a/Resources/Prototypes/DeltaV/Access/cargo.yml
+++ b/Resources/Prototypes/DeltaV/Access/cargo.yml
@@ -1,0 +1,3 @@
+﻿- type: accessLevel
+  id: Orders
+  name: id-card-access-level-orders # Custom access level that allows the approval of orders

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -713,7 +713,7 @@
     energy: 1.6
     color: "#b89f25"
   - type: AccessReader
-    access: [["Cargo"]]
+    access: [["Orders"]] # DeltaV - see Resources/Prototypes/DeltaV/Access/cargo.yml
   - type: DeviceNetwork
     deviceNetId: Wireless
     receiveFrequencyId: BasicDevice

--- a/Resources/Prototypes/Nyanotrasen/Access/cargo.yml
+++ b/Resources/Prototypes/Nyanotrasen/Access/cargo.yml
@@ -1,3 +1,3 @@
 - type: accessLevel
   id: Mail
-  name: Mail
+  name: id-card-access-level-mail

--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -13,6 +13,7 @@
   - External
   extendedAccess:
   - Salvage
+  - Orders # DeltaV - Orders, see Resources/Prototypes/DeltaV/Access/cargo.yml
 
 - type: startingGear
   id: CargoTechGear

--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -32,6 +32,7 @@
   - Maintenance
   - External
   - Command
+  - Orders # DeltaV - Orders, see Resources/Prototypes/DeltaV/Access/cargo.yml
 
 - type: startingGear
   id: QuartermasterGear


### PR DESCRIPTION
## About the PR
Require a new access level for approving orders (anyone can still place them)

This is granted by default to the Head of Logistics, the captain. On extended access, the logistic technicians will also get it. It can also be granted via an ID card console to any ID.

## Why / Balance
Discussed in Discord

**Changelog**
:cl:
- tweak: Approving cargo orders now requires the Orders access level
