### PR TITLE
Update changelog system to be datetime based and merge all files

### DIFF
--- a/Content.Client/Changelog/ChangelogManager.cs
+++ b/Content.Client/Changelog/ChangelogManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
@@ -25,8 +26,8 @@ namespace Content.Client.Changelog
         [Dependency] private readonly IConfigurationManager _configManager = default!;
 
         public bool NewChangelogEntries { get; private set; }
-        public int LastReadId { get; private set; }
-        public int MaxId { get; private set; }
+        public DateTime LastReadTime { get; private set; } // Modified, see EOF
+        public DateTime MaxTime { get; private set; } // Modified, see EOF
 
         public event Action? NewChangelogEntriesChanged;
 
@@ -35,7 +36,7 @@ namespace Content.Client.Changelog
         ///     stores the new ID to disk and clears <see cref="NewChangelogEntries"/>.
         /// </summary>
         /// <remarks>
-        ///     <see cref="LastReadId"/> is NOT cleared
+        ///     <see cref="LastReadTime"/> is NOT cleared
         ///     since that's used in the changelog menu to show the "since you last read" bar.
         /// </remarks>
         public void SaveNewReadId()
@@ -43,9 +44,9 @@ namespace Content.Client.Changelog
             NewChangelogEntries = false;
             NewChangelogEntriesChanged?.Invoke();
 
-            using var sw = _resource.UserData.OpenWriteText(new ($"/changelog_last_seen_{_configManager.GetCVar(CCVars.ServerId)}"));
+            using var sw = _resource.UserData.OpenWriteText(new ($"/changelog_last_seen_{_configManager.GetCVar(CCVars.ServerId)}_datetime")); // Modified, see EOF
 
-            sw.Write(MaxId.ToString());
+            sw.Write(MaxTime.ToString("O")); // Modified, see EOF
         }
 
         public async void Initialize()
@@ -58,24 +59,46 @@ namespace Content.Client.Changelog
                 return;
             }
 
-            MaxId = changelog.Max(c => c.Id);
+            MaxTime = changelog.Max(c => c.Time); // Modified, see EOF
 
-            var path = new ResPath($"/changelog_last_seen_{_configManager.GetCVar(CCVars.ServerId)}");
-            if(_resource.UserData.TryReadAllText(path, out var lastReadIdText))
+            // Begin modified codeblock, see EOF
+            var path = new ResPath($"/changelog_last_seen_{_configManager.GetCVar(CCVars.ServerId)}_datetime");
+            if(_resource.UserData.TryReadAllText(path, out var lastReadTimeText))
             {
-                LastReadId = int.Parse(lastReadIdText);
+                if (Regex.IsMatch(lastReadTimeText,
+                        @"^([\+-]?\d{4}(?!\d{2}\b))((-?)((0[1-9]|1[0-2])(\3([12]\d|0[1-9]|3[01]))?|W([0-4]\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\d|[12]\d{2}|3([0-5]\d|6[1-6])))([T\s]((([01]\d|2[0-3])((:?)[0-5]\d)?|24\:?00)([\.,]\d+(?!:))?)?(\17[0-5]\d([\.,]\d+)?)?([zZ]|([\+-])([01]\d|2[0-3]):?([0-5]\d)?)?)?)?$"))
+                {
+                    LastReadTime = DateTime.ParseExact(lastReadTimeText, "O", CultureInfo.InvariantCulture);
+                }
             }
 
-            NewChangelogEntries = LastReadId < MaxId;
+            NewChangelogEntries = LastReadTime < MaxTime;
+            // End modified codeblock
 
             NewChangelogEntriesChanged?.Invoke();
         }
 
-        public Task<List<ChangelogEntry>> LoadChangelog()
+        // Begin modified codeblock, see EOF
+        public async Task<List<ChangelogEntry>> LoadChangelog()
+        {
+            var paths = _resource.ContentFindFiles("/Changelog/")
+                .Where(filePath => filePath.Extension == "yml")
+                .ToArray();
+
+            var result = new List<ChangelogEntry>();
+            foreach (var path in paths)
+            {
+                var changelog = await LoadChangelogFile(path);
+                result = result.Union(changelog).ToList();
+            }
+            return result.OrderBy(x => x.Time).ToList();
+        }
+
+        private Task<List<ChangelogEntry>> LoadChangelogFile(ResPath path) // end modified codeblock
         {
             return Task.Run(() =>
             {
-                var yamlData = _resource.ContentFileReadYaml(new ("/Changelog/Changelog.yml"));
+                var yamlData = _resource.ContentFileReadYaml(path); // Modified, see EOF
 
                 if (yamlData.Documents.Count == 0)
                     return new List<ChangelogEntry>();
@@ -126,3 +149,7 @@ namespace Content.Client.Changelog
         }
     }
 }
+
+
+// This file was extensively modified to allow for datetime based changelogs instead of relying on IDs.
+// This is because our IDs are much lower then Wizdens, and if we use their entries, the server will not properly show new changes

--- a/Content.Client/Changelog/ChangelogWindow.xaml.cs
+++ b/Content.Client/Changelog/ChangelogWindow.xaml.cs
@@ -48,13 +48,13 @@ namespace Content.Client.Changelog
                 .GroupBy(e => e.Time.ToLocalTime().Date)
                 .OrderByDescending(c => c.Key);
 
-            var hasRead = _changelog.MaxId <= _changelog.LastReadId;
+            var hasRead = _changelog.MaxTime <= _changelog.LastReadTime; // Modified, see EOF
             foreach (var dayEntries in byDay)
             {
                 var day = dayEntries.Key;
 
                 var groupedEntries = dayEntries
-                    .GroupBy(c => (c.Author, Read: c.Id <= _changelog.LastReadId))
+                    .GroupBy(c => (c.Author, Read: c.Time <= _changelog.LastReadTime)) // Modified, see EOF
                     .OrderBy(c => c.Key.Read)
                     .ThenBy(c => c.Key.Author);
 
@@ -203,3 +203,6 @@ namespace Content.Client.Changelog
         }
     }
 }
+
+// This file was extensively modified to allow for datetime based changelogs instead of relying on IDs.
+// This is because our IDs are much lower then Wizdens, and if we use their entries, the server will not properly show new changes

--- a/Tools/actions_changelogs_since_last_run.py
+++ b/Tools/actions_changelogs_since_last_run.py
@@ -19,7 +19,7 @@ GITHUB_TOKEN      = os.environ["GITHUB_TOKEN"]
 
 DISCORD_WEBHOOK_URL = os.environ.get("DISCORD_WEBHOOK_URL")
 
-CHANGELOG_FILE = "Resources/Changelog/Changelog.yml"
+CHANGELOG_FILE = "Resources/Changelog/DeltaVChangelog.yml"
 
 TYPES_TO_EMOJI = {
     "Fix":    "🐛",


### PR DESCRIPTION
## About the PR
Datetime is much better for this because we'll never catch up to wizdens high changelog ids. Also readd the changelog merging code because otherwise ours doesnt show
