### PR TITLE
Prevent /suicide usage

### DIFF
--- a/Content.Server/Chat/SuicideSystem.cs
+++ b/Content.Server/Chat/SuicideSystem.cs
@@ -41,6 +41,8 @@ namespace Content.Server.Chat
             if (SuicideAttemptBlocked(victim, suicideEvent))
                 return false;
 
+            return false; // DeltaV - Prevent Suicide. We allow the event to go out anyways in case anything relies on the event for a message or whatever.
+
             bool environmentSuicide = false;
             // If you are critical, you wouldn't be able to use your surroundings to suicide, so you do the default suicide
             if (!_mobState.IsCritical(victim, mobState))


### PR DESCRIPTION
Cancels the event before it actually kills you, but still allows the event to go out in case any systems require it to stop other actions.

This'll just make it act like running /ghost 99% of the time.