### PR TITLE
Resize Skull

### DIFF
--- a/Resources/Prototypes/Body/Parts/skeleton.yml
+++ b/Resources/Prototypes/Body/Parts/skeleton.yml
@@ -41,6 +41,7 @@
     - type: Sprite
       sprite: Mobs/Species/Skeleton/parts.rsi
       state: "skull_icon"
+      scale: 0.5, 0.5
     - type: Icon
       sprite: Mobs/Species/Skeleton/parts.rsi
       state: "skull_icon"

--- a/Resources/Prototypes/Body/Parts/skeleton.yml
+++ b/Resources/Prototypes/Body/Parts/skeleton.yml
@@ -41,7 +41,7 @@
     - type: Sprite
       sprite: Mobs/Species/Skeleton/parts.rsi
       state: "skull_icon"
-      scale: 0.5, 0.5
+      scale: 0.5, 0.5 # DeltaV - Scale down sprite because it looks too big
     - type: Icon
       sprite: Mobs/Species/Skeleton/parts.rsi
       state: "skull_icon"


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR<!-- What did you change in this PR? -->
Resized Skulls

## Why / Balance
I scaled it down because skulls being about as big as a human was a bit silly.

## Technical details
I added scaling to the prototype's sprite.

## Media

![Screenshot 2023-10-09 121824](https://github.com/DeltaV-Station/Delta-v-rebase/assets/113228053/36c196e1-93cf-4070-82ce-538df82d999e)

I'll eventually make a PR for rescaling other items in one single PR, I just wanted to get this one out of the way first. 

**Changelog**

:cl:
- tweak: Skull Size
