### PR TITLE
Moth RGB 2: The electric boogaloo

### DIFF
--- a/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Preferences/UI/HumanoidProfileEditor.xaml.cs
@@ -642,6 +642,8 @@ namespace Content.Client.Preferences.UI
 
             var skin = _prototypeManager.Index<SpeciesPrototype>(Profile.Species).SkinColoration;
 
+            var skinColor = _prototypeManager.Index<SpeciesPrototype>(Profile.Species).DefaultSkinTone;
+
             switch (skin)
             {
                 case HumanoidSkinColor.HumanToned:
@@ -671,6 +673,7 @@ namespace Content.Client.Preferences.UI
                     break;
                 }
                 case HumanoidSkinColor.TintedHues:
+                case HumanoidSkinColor.TintedHuesSkin: // DeltaV - Tone blending
                 {
                     if (!_rgbSkinColorContainer.Visible)
                     {
@@ -678,7 +681,12 @@ namespace Content.Client.Preferences.UI
                         _rgbSkinColorContainer.Visible = true;
                     }
 
-                    var color = SkinColor.TintedHues(_rgbSkinColorSelector.Color);
+                    var color = skin switch // DeltaV - Tone blending
+                    {
+                        HumanoidSkinColor.TintedHues => SkinColor.TintedHues(_rgbSkinColorSelector.Color),
+                        HumanoidSkinColor.TintedHuesSkin => SkinColor.TintedHuesSkin(_rgbSkinColorSelector.Color, skinColor),
+                        _ => Color.White
+                    };
 
                     CMarkings.CurrentSkinColor = color;
                     Profile = Profile.WithCharacterAppearance(Profile.Appearance.WithSkinColor(color));

--- a/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
+++ b/Content.Shared/Humanoid/HumanoidCharacterAppearance.cs
@@ -104,6 +104,8 @@ namespace Content.Shared.Humanoid
                 HumanoidSkinColor.HumanToned => Humanoid.SkinColor.HumanSkinTone(speciesPrototype.DefaultHumanSkinTone),
                 HumanoidSkinColor.Hues => speciesPrototype.DefaultSkinTone,
                 HumanoidSkinColor.TintedHues => Humanoid.SkinColor.TintedHues(speciesPrototype.DefaultSkinTone),
+                // DeltaV - Blended tint for moths
+                HumanoidSkinColor.TintedHuesSkin => Humanoid.SkinColor.TintedHuesSkin(speciesPrototype.DefaultSkinTone, speciesPrototype.DefaultSkinTone),
                 _ => Humanoid.SkinColor.ValidHumanSkinTone
             };
 
@@ -153,6 +155,7 @@ namespace Content.Shared.Humanoid
             var newEyeColor = random.Pick(RealisticEyeColors);
 
             var skinType = IoCManager.Resolve<IPrototypeManager>().Index<SpeciesPrototype>(species).SkinColoration;
+            var skinTone = IoCManager.Resolve<IPrototypeManager>().Index<SpeciesPrototype>(species).DefaultSkinTone; // DeltaV, required for tone blending
 
             var newSkinColor = Humanoid.SkinColor.ValidHumanSkinTone;
             switch (skinType)
@@ -168,11 +171,22 @@ namespace Content.Shared.Humanoid
                     var bbyte = random.NextByte();
                     newSkinColor = new Color(rbyte, gbyte, bbyte);
                     break;
+                case HumanoidSkinColor.TintedHuesSkin: // DeltaV, tone blending
+                    rbyte = random.NextByte();
+                    gbyte = random.NextByte();
+                    bbyte = random.NextByte();
+                    newSkinColor = new Color(rbyte, gbyte, bbyte);
+                    break;
             }
 
             if (skinType == HumanoidSkinColor.TintedHues)
             {
                 newSkinColor = Humanoid.SkinColor.ValidTintedHuesSkinTone(newSkinColor);
+            }
+
+            if (skinType == HumanoidSkinColor.TintedHuesSkin) // DeltaV, tone blending
+            {
+                newSkinColor = Humanoid.SkinColor.ValidTintedHuesSkinTone(skinTone, newSkinColor);
             }
 
             return new HumanoidCharacterAppearance(newHairStyle, newHairColor, newFacialHairStyle, newHairColor, newEyeColor, newSkinColor, new ());

--- a/Content.Shared/Humanoid/SkinColor.cs
+++ b/Content.Shared/Humanoid/SkinColor.cs
@@ -12,9 +12,9 @@ public static class SkinColor
     /// </summary>
     /// <param name="color">The color to validate</param>
     /// <returns>Validated tinted hue skin tone</returns>
-    public static Color ValidTintedHuesSkinTone(Color color)
+    public static Color ValidTintedHuesSkinTone(Color color, Color? skinTone = null)
     {
-        return TintedHues(color);
+        return skinTone != null ? TintedHuesSkin(color, skinTone.Value) : TintedHues(color);
     }
 
     /// <summary>
@@ -128,6 +128,33 @@ public static class SkinColor
     }
 
     /// <summary>
+    ///     DeltaV - Convert a color to the 'tinted hues' skin tone type, and blend it into skinColor
+    /// </summary>
+    /// <param name="color">Color to convert</param>
+    /// <returns>Tinted hue color</returns>
+    public static Color TintedHuesSkin(Color color, Color skinColor, float blendFactor = 0.2f)
+    {
+        var colorHsv = Color.ToHsv(color);
+        var skinHsv = Color.ToHsv(skinColor);
+
+        colorHsv = new Vector4(
+            skinHsv.X + (colorHsv.X - skinHsv.X) * blendFactor,
+            skinHsv.Y + (colorHsv.Y - skinHsv.Y) * blendFactor,
+            skinHsv.Z + (colorHsv.Z - skinHsv.Z) * blendFactor,
+            skinHsv.W
+        );
+
+        colorHsv = new Vector4(
+            Math.Clamp(colorHsv.X, 0f, 360f),
+            Math.Clamp(colorHsv.Y, 0f, 1f),
+            Math.Clamp(colorHsv.Z, 0f, 1f),
+            colorHsv.W
+        );
+
+        return Color.FromHsv(colorHsv);
+    }
+
+    /// <summary>
     ///     Verify if this color is a valid tinted hue color type, or not.
     /// </summary>
     /// <param name="color">The color to verify</param>
@@ -144,6 +171,7 @@ public static class SkinColor
         {
             HumanoidSkinColor.HumanToned => VerifyHumanSkinTone(color),
             HumanoidSkinColor.TintedHues => VerifyTintedHues(color),
+            HumanoidSkinColor.TintedHuesSkin => VerifyTintedHues(color), // DeltaV - Tone blending
             HumanoidSkinColor.Hues => true,
             _ => false,
         };
@@ -155,6 +183,7 @@ public static class SkinColor
         {
             HumanoidSkinColor.HumanToned => ValidHumanSkinTone,
             HumanoidSkinColor.TintedHues => ValidTintedHuesSkinTone(color),
+            HumanoidSkinColor.TintedHuesSkin => ValidTintedHuesSkinTone(color), // DeltaV - Tone blending
             _ => color
         };
     }
@@ -165,4 +194,5 @@ public enum HumanoidSkinColor : byte
     HumanToned,
     Hues,
     TintedHues, //This gives a color tint to a humanoid's skin (10% saturation with full hue range).
+    TintedHuesSkin, // DeltaV - Default TintedHues assumes the texture will have the proper skin color, but moths dont
 }

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -7,7 +7,7 @@
   defaultSkinTone: "#ffda93"
   markingLimits: MobMothMarkingLimits
   dollPrototype: MobMothDummy
-  skinColoration: Hues
+  skinColoration: TintedHuesSkin # DeltaV - No rgb moths, literally 1849
   maleFirstNames: names_moth_first_male
   femaleFirstNames: names_moth_first_female
   lastNames: names_moth_last


### PR DESCRIPTION
## About the PR
Funny RGB sliders but not bad

## Why / Balance
RGB moths look like shit, this blends the selected color with the default moth skintone.

## Media
![Content Client_YEUTFOEym8](https://github.com/DeltaV-Station/Delta-v-rebase/assets/49997488/fce77fe3-0969-4d57-978b-c17189062f17)
0, 0, 0
![Content Client_1F7KpVkoRd](https://github.com/DeltaV-Station/Delta-v-rebase/assets/49997488/075f5ed3-4ccd-47f5-a49f-3e88c2ad82ab)
255, 255, 255
![Content Client_1iVOipGOyi](https://github.com/DeltaV-Station/Delta-v-rebase/assets/49997488/ced8b27f-cdd3-49ed-94a3-62f9e3497331)
255, 0, 0
![Content Client_agok9doa6t](https://github.com/DeltaV-Station/Delta-v-rebase/assets/49997488/b98398d1-60eb-4510-ac33-7cd1799e521a)
0, 255, 0
![Content Client_oiQvjszbLD](https://github.com/DeltaV-Station/Delta-v-rebase/assets/49997488/8ff6e88c-948b-4041-850f-8d87c18fe05e)
0, 0, 255

**Changelog**
:cl:
- tweak: Moth coloration has been changed, existing characters might look slightly weird
