### PR TITLE
Another harpy bugfix

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/Customization/Markings/harpy.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/Customization/Markings/harpy.yml
@@ -6,6 +6,14 @@
   bodyPart: RArm
   markingCategory: Arms
   speciesRestriction: [Harpy]
+  coloring:
+    default:
+      type:
+        !type:CategoryColoring
+          category: Hair
+      fallbackTypes:
+        - !type:SimpleColoring
+          color: "#964b00"
   sprites:
     - sprite: DeltaV/Mobs/Customization/Harpy/harpy_wings.rsi
       state: harpy
@@ -15,6 +23,14 @@
   bodyPart: Head
   markingCategory: HeadTop
   speciesRestriction: [Harpy]
+  coloring:
+    default:
+      type:
+        !type:CategoryColoring
+          category: Hair
+      fallbackTypes:
+        - !type:SimpleColoring
+          color: "#964b00"
   sprites:
     - sprite: DeltaV/Mobs/Customization/Harpy/harpy_ears.rsi
       state: harpy_ears_default
@@ -24,6 +40,14 @@
   bodyPart: Tail
   markingCategory: Tail
   speciesRestriction: [Harpy]
+  coloring:
+    default:
+      type:
+        !type:CategoryColoring
+          category: Hair
+      fallbackTypes:
+        - !type:SimpleColoring
+          color: "#964b00"
   sprites:
     - sprite: DeltaV/Mobs/Customization/Harpy/harpy_tails.rsi
       state: phoenix_tail


### PR DESCRIPTION
## About the PR
This PR provides a fix for #180 4th bug, concerning harpies defaulting their colors to skin tone when randomly generated(Such as via the Metempsychosis machine). I've accomplished this by setting the three default markings to use the same color as the character's hair, with a fallback of plain brown if the character is bald. Hopefully this will solve the problem of Metempsychosis harpies being "Very fucking ugly". 

## Media
![image](https://github.com/DeltaV-Station/Delta-v-rebase/assets/16548818/45318d6c-fb49-4f08-be4d-0a5b620385c9)
