### PR TITLE
Minor buff to the mindbreaker .38

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/special.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/special.yml
@@ -65,6 +65,6 @@
       ammo:
         reagents:
         - ReagentId: MindbreakerToxin
-          Quantity: 7
+          Quantity: 9
   - type: SolutionTransfer
-    maxTransferAmount: 7
+    maxTransferAmount: 9


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changes the amount of mindbreaker toxin in a .38 mindbreaker from 7u to 9u
Since they only get 4 bullets at start, it allows them the ability to not have to hit all shots.
